### PR TITLE
Fix package import error and add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# LeaveBot
+
+This project contains a simple HR assistant built with Streamlit. The code lives inside the `leavebot` package.
+
+## Running the app
+
+1. Install Python 3.8+ and the required packages:
+   ```bash
+   pip install streamlit numpy openai
+   ```
+   (Add any other dependencies you require.)
+
+2. Run the Streamlit application from the repository root:
+   ```bash
+   streamlit run leavebot/main.py
+   ```
+
+The `leavebot` directory now contains an `__init__.py` file so it can be imported as a package.

--- a/leavebot/__init__.py
+++ b/leavebot/__init__.py
@@ -1,0 +1,2 @@
+# LeaveBot package initialization
+


### PR DESCRIPTION
## Summary
- add `leavebot/__init__.py` so Python can import the package
- document how to run the Streamlit app in `README.md`

## Testing
- `python -m pip install -r leavebot/requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6851002abf5c8323a7649bc2dfbcfedd